### PR TITLE
Add support to control synth via computer keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a web-based synth using the [Web Audio API](https://developer.mozilla.or
 
 * [x] Get some noise: get the app to produce _any_ sound
 * [x] Implement a simple synth topology (OSC -> AD -> OUT)
-* [ ] Support computer keyboard as musical keyboard
+* [x] Support computer keyboard as musical keyboard
 * [ ] Implement a more complex synth topology (multiple oscillators, EGs, LFOs, etc)
 * [ ] Have elegant UI components to control the synth
 

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -26,6 +26,7 @@ const Keyboard = ({ onKeyDown }: KeyboardProps) => {
     if (ev.repeat) return;
     if (isInKeys(key)) {
       const note = getMidiValue(keys.indexOf(key), octave);
+      if (note < 0 && 127 < note) return;
       onKeyDown(note);
     } else if (key === 'x' && octave < 8) {
       setOctave(currentOctave => ++currentOctave);
@@ -44,7 +45,12 @@ const Keyboard = ({ onKeyDown }: KeyboardProps) => {
 
   return (
     <div style={{ display: 'flex' }}>
-      {keys.map((key, index) => <Key key={getMidiValue(index, octave)} midiNote={getMidiValue(index, octave)} onKeyDown={onKeyDown} />)}
+      {keys.map((key, index) => {
+        const midiNote = getMidiValue(index, octave);
+        if (midiNote > 127) return null;
+        return <Key key={midiNote} midiNote={midiNote} onKeyDown={onKeyDown} />;
+      })
+      }
     </div>
   );
 }

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -8,18 +8,18 @@ const keys = [
 
 const isInKeys = (x: string): x is typeof keys[number] => {
   return keys.includes(x as typeof keys[number]);
-}
+};
 
 const getMidiValue = (baseNote: number, octave: number) => {
-  return baseNote + (octave + 2) * 12
-}
+  return baseNote + (octave + 2) * 12;
+};
 
 interface KeyboardProps {
   onKeyDown: OnKeyDown;
 }
 
 const Keyboard = ({ onKeyDown }: KeyboardProps) => {
-  const [octave, setOctave] = useState(3)
+  const [octave, setOctave] = useState(3);
 
   const handleOnKeyDown = useCallback((ev: KeyboardEvent) => {
     const key = ev.key;
@@ -28,9 +28,9 @@ const Keyboard = ({ onKeyDown }: KeyboardProps) => {
       const note = getMidiValue(keys.indexOf(key), octave);
       onKeyDown(note);
     } else if (key === 'x' && octave < 8) {
-      setOctave(currentOctave => ++currentOctave)
+      setOctave(currentOctave => ++currentOctave);
     } else if (key === 'z' && octave > -2) {
-      setOctave(currentOctave => --currentOctave)
+      setOctave(currentOctave => --currentOctave);
     }
   }, [octave, onKeyDown]);
 

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import Key from "./Key";
 import { OnKeyDown } from "../App";
 
@@ -6,24 +6,35 @@ const keys = [
   'a', 'w', 's', 'e', 'd', 'f', 't', 'g', 'y', 'h', 'u', 'j', 'k', 'o', 'l'
 ];
 
-const midiNotes = keys.map((key, index) => ({
-  key,
-  value: 60 +  index
-}));
-
 interface KeyboardProps {
   onKeyDown: OnKeyDown;
 }
 
 const Keyboard = ({ onKeyDown }: KeyboardProps) => {
+  const [octave, setOctave] = useState(0)
+  const [midiNotes, setMidiNotes] = useState(Array<{key: string; value: number;}>())
+
+  useEffect(() => {
+    const notes = keys.map((key, index) => ({
+      key,
+      value: 60 + (octave * 12) + index
+    }));
+
+    setMidiNotes(notes);
+  }, [octave]);
+
   const handleOnKeyDown = useCallback((ev: KeyboardEvent) => {
     const key = ev.key;
     if (ev.repeat) return;
     if (keys.includes(key)) {
       const note = midiNotes.find(midiNote => midiNote.key === ev.key)?.value ?? 60;
       onKeyDown(note);
+    } else if (key === 'x') {
+      setOctave(currentOctave => ++currentOctave)
+    } else if (key === 'z') {
+      setOctave(currentOctave => --currentOctave)
     }
-  }, [onKeyDown]);
+  }, [midiNotes, onKeyDown]);
 
   useEffect(() => {
     document.removeEventListener('keydown', handleOnKeyDown);

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -27,9 +27,9 @@ const Keyboard = ({ onKeyDown }: KeyboardProps) => {
     if (isInKeys(key)) {
       const note = getMidiValue(keys.indexOf(key), octave);
       onKeyDown(note);
-    } else if (key === 'x') {
+    } else if (key === 'x' && octave < 8) {
       setOctave(currentOctave => ++currentOctave)
-    } else if (key === 'z') {
+    } else if (key === 'z' && octave > -2) {
       setOctave(currentOctave => --currentOctave)
     }
   }, [octave, onKeyDown]);

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -1,19 +1,41 @@
-import React from "react";
+import React, { useCallback, useEffect } from "react";
 import Key from "./Key";
 import { OnKeyDown } from "../App";
 
-const midiNotes = [
-  60, 62, 64, 65, 67, 69, 71, 72
+const keys = [
+  'a', 'w', 's', 'e', 'd', 'f', 't', 'g', 'y', 'h', 'u', 'j', 'k', 'o', 'l'
 ];
+
+const midiNotes = keys.map((key, index) => ({
+  key,
+  value: 60 +  index
+}));
 
 interface KeyboardProps {
   onKeyDown: OnKeyDown;
 }
 
 const Keyboard = ({ onKeyDown }: KeyboardProps) => {
+  const handleOnKeyDown = useCallback((ev: KeyboardEvent) => {
+    const key = ev.key;
+    if (ev.repeat) return;
+    if (keys.includes(key)) {
+      const note = midiNotes.find(midiNote => midiNote.key === ev.key)?.value ?? 60;
+      onKeyDown(note);
+    }
+  }, [onKeyDown]);
+
+  useEffect(() => {
+    document.removeEventListener('keydown', handleOnKeyDown);
+    document.addEventListener('keydown', handleOnKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleOnKeyDown);
+    }
+  }, [handleOnKeyDown]);
+
   return (
     <div style={{ display: 'flex' }}>
-      {midiNotes.map(midiNote => <Key midiNote={midiNote} onKeyDown={onKeyDown} />)}
+      {midiNotes.map(({ value })=> <Key midiNote={value} onKeyDown={onKeyDown} />)}
     </div>
   );
 }

--- a/src/Keyboard/index.tsx
+++ b/src/Keyboard/index.tsx
@@ -4,37 +4,35 @@ import { OnKeyDown } from "../App";
 
 const keys = [
   'a', 'w', 's', 'e', 'd', 'f', 't', 'g', 'y', 'h', 'u', 'j', 'k', 'o', 'l'
-];
+] as const;
+
+const isInKeys = (x: string): x is typeof keys[number] => {
+  return keys.includes(x as typeof keys[number]);
+}
+
+const getMidiValue = (baseNote: number, octave: number) => {
+  return baseNote + (octave + 2) * 12
+}
 
 interface KeyboardProps {
   onKeyDown: OnKeyDown;
 }
 
 const Keyboard = ({ onKeyDown }: KeyboardProps) => {
-  const [octave, setOctave] = useState(0)
-  const [midiNotes, setMidiNotes] = useState(Array<{key: string; value: number;}>())
-
-  useEffect(() => {
-    const notes = keys.map((key, index) => ({
-      key,
-      value: 60 + (octave * 12) + index
-    }));
-
-    setMidiNotes(notes);
-  }, [octave]);
+  const [octave, setOctave] = useState(3)
 
   const handleOnKeyDown = useCallback((ev: KeyboardEvent) => {
     const key = ev.key;
     if (ev.repeat) return;
-    if (keys.includes(key)) {
-      const note = midiNotes.find(midiNote => midiNote.key === ev.key)?.value ?? 60;
+    if (isInKeys(key)) {
+      const note = getMidiValue(keys.indexOf(key), octave);
       onKeyDown(note);
     } else if (key === 'x') {
       setOctave(currentOctave => ++currentOctave)
     } else if (key === 'z') {
       setOctave(currentOctave => --currentOctave)
     }
-  }, [midiNotes, onKeyDown]);
+  }, [octave, onKeyDown]);
 
   useEffect(() => {
     document.removeEventListener('keydown', handleOnKeyDown);
@@ -46,7 +44,7 @@ const Keyboard = ({ onKeyDown }: KeyboardProps) => {
 
   return (
     <div style={{ display: 'flex' }}>
-      {midiNotes.map(({ value })=> <Key midiNote={value} onKeyDown={onKeyDown} />)}
+      {keys.map((key, index) => <Key key={getMidiValue(index, octave)} midiNote={getMidiValue(index, octave)} onKeyDown={onKeyDown} />)}
     </div>
   );
 }


### PR DESCRIPTION
Simulate computer keyboard as a piano. Keys from "a" to "l" work as the white keys of a piano, the row above is for the black keys. Octave can be set with "z" and "x" keys.